### PR TITLE
Use cstubs for FDBKeyValue struct as it's packed

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,30 @@
 (library
+  (public_name fdb.stubs)
+  (name stubs)
+  (modules stubs)
+  (libraries ctypes.stubs ctypes.foreign))
+
+(executable
+ (name stubs_c_gen)
+ (modules stubs_c_gen)
+ (libraries stubs ctypes.stubs ctypes))
+
+(rule (with-stdout-to "stubs_ml_gen.c" (run "./stubs_c_gen.exe")))
+
+(rule
+ (targets stubs_ml_gen.exe)
+ (deps    (:stubs_ml_gen ./stubs_ml_gen.c))
+ (action (bash "\
+%{cc} %{stubs_ml_gen} \
+  -I `dirname %{lib:ctypes:ctypes_cstubs_internals.h}` \
+  -I %{ocaml_where} -o %{targets}")))
+
+(rule (with-stdout-to "stubs_type.ml" (run "./stubs_ml_gen.exe")))
+
+(library
  (name fdb)
  (public_name fdb)
- (libraries ctypes.foreign bigarray)
- (ocamlopt_flags (-cclib -lfdb_c)))
+ (modules raw fdb stubs_type)
+ (libraries fdb.stubs ctypes.stubs ctypes.foreign bigarray)
+ (ocamlopt_flags (-cclib -lfdb_c))
+ (flags (:standard -w -9-27)))

--- a/src/fdb.ml
+++ b/src/fdb.ml
@@ -102,21 +102,21 @@ module Make (Io : IO) = struct
   end
 
   module KeyValue = struct
-    type t = (Raw.fdb_key_value, [`Struct]) structured
+    type t = (Raw.Key_value.t, [`Struct]) structured
 
     let key t =
-      let length = getf t Raw.fdbkv_key_length in
-      let key_ptr = getf t Raw.fdbkv_key in
+      let length = getf t Raw.Key_value.fdbkv_key_length in
+      let key_ptr = getf t Raw.Key_value.fdbkv_key in
       string_from_ptr key_ptr ~length
 
     let value t =
-      let length = getf t Raw.fdbkv_value_length in
-      let value_ptr = getf t Raw.fdbkv_value in
+      let length = getf t Raw.Key_value.fdbkv_value_length in
+      let value_ptr = getf t Raw.Key_value.fdbkv_value in
       bigarray_of_ptr array1 length Bigarray.char value_ptr
   end
 
   module RangeResult = struct
-    type t = {head: Raw.fdb_key_value structure CArray.t; tail: tail}
+    type t = {head: Raw.Key_value.t structure CArray.t; tail: tail}
 
     and tail = (unit -> t or_error io) option
 
@@ -166,7 +166,7 @@ module Make (Io : IO) = struct
       Future.to_io future
       >>=? fun future ->
       let finalise _ = Raw.future_destroy future in
-      let result_ptr = allocate ~finalise (ptr_opt Raw.fdb_key_value_t) None in
+      let result_ptr = allocate ~finalise (ptr_opt Raw.Key_value.t) None in
       let length_ptr = allocate int 0 in
       let more_ptr = allocate int 0 in
       let error =

--- a/src/raw.ml
+++ b/src/raw.ml
@@ -29,19 +29,7 @@ let fdb_transaction_option = int
 let fdb_transaction_t = ptr void
 
 (* Key value *)
-type fdb_key_value
-
-let fdb_key_value_t : fdb_key_value structure typ = structure "fdb_key_value"
-
-let fdbkv_key = field fdb_key_value_t "key" (ptr char)
-
-let fdbkv_key_length = field fdb_key_value_t "key_length" int
-
-let fdbkv_value = field fdb_key_value_t "value" (ptr char)
-
-let fdbkv_value_length = field fdb_key_value_t "value_length" int
-
-let () = seal fdb_key_value_t
+module Key_value = Stubs.Key_value(Stubs_type)
 
 (* Top-level functions *)
 let select_api_version =
@@ -230,7 +218,7 @@ let future_get_string_array =
 let future_get_key_value_array =
   foreign "fdb_future_get_keyvalue_array"
     ( fdb_future_t
-    @-> ptr (ptr_opt fdb_key_value_t)
+    @-> ptr (ptr_opt Key_value.t)
     @-> ptr int @-> ptr fdb_bool_t @-> returning fdb_error_t )
 
 (* Errors *)

--- a/src/stubs.ml
+++ b/src/stubs.ml
@@ -1,0 +1,17 @@
+module Key_value(S : Cstubs_structs.TYPE) = struct
+  open S
+
+  type t
+
+  let t : t Ctypes.structure typ = structure "keyvalue"
+
+  let fdbkv_key = field t "key" (ptr char)
+
+  let fdbkv_key_length = field t "key_length" int
+
+  let fdbkv_value = field t "value" (ptr char)
+
+  let fdbkv_value_length = field t "value_length" int
+
+  let () = seal t
+end

--- a/src/stubs_c_gen.ml
+++ b/src/stubs_c_gen.ml
@@ -1,0 +1,8 @@
+let c_headers = "#define FDB_API_VERSION 600\n#include <foundationdb/fdb_c.h>"
+
+let main () =
+  Format.printf "%s@\n" c_headers;
+  Cstubs_structs.write_c Format.std_formatter (module Stubs.Key_value);
+  flush stdout
+
+let () = main ()


### PR DESCRIPTION
The calculated field offsets for the struct `FDBKeyValue` were wrong, as it's defined with `#pragma pack(push, 4)`. This caused segmentation faults when reading from the struct. This PR uses cstubs from `ctypes` to determine the field offsets in a more robust manner.